### PR TITLE
Add GPX file support

### DIFF
--- a/web-app/app.py
+++ b/web-app/app.py
@@ -24,7 +24,7 @@ os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 # Enregistrer les blueprints
 app.register_blueprint(analysis_bp)
 
-ALLOWED_EXTENSIONS = {'kml', 'kmz'}
+ALLOWED_EXTENSIONS = {'kml', 'kmz', 'gpx'}
 
 def allowed_file(filename):
     """Vérifie si le fichier a une extension autorisée."""

--- a/web-app/app/api/routes.py
+++ b/web-app/app/api/routes.py
@@ -5,13 +5,14 @@ Routes API REST de l'application.
 from flask import request, jsonify
 from app.api import bp
 from app.services.kml_parser import KMLParser
+from app.services.gpx_parser import GPXParser
 from app.services.file_service import FileService
 from app.services.timing_tools import track_time
 
 @bp.route('/upload', methods=['POST'])
 @track_time
 def upload_file():
-    """Endpoint pour uploader et traiter un fichier KML."""
+    """Endpoint pour uploader et traiter un fichier KML ou GPX."""
     try:
         if 'file' not in request.files:
             return jsonify({'success': False, 'error': 'Aucun fichier sélectionné'}), 400
@@ -25,7 +26,11 @@ def upload_file():
         
         # Traiter le fichier
         content = FileService.save_uploaded_file(file)
-        result = KMLParser.parse_kml_coordinates(content, display_mode)
+        ext = file.filename.rsplit('.', 1)[1].lower()
+        if ext == 'gpx':
+            result = GPXParser.parse_gpx_coordinates(content)
+        else:
+            result = KMLParser.parse_kml_coordinates(content, display_mode)
         
         if result['success']:
             return jsonify(result)
@@ -46,7 +51,7 @@ def upload_file():
 
 @bp.route('/sample-files')
 def list_sample_files():
-    """Liste les fichiers KML d'exemple disponibles."""
+    """Liste les fichiers d'exemple disponibles."""
     try:
         sample_files = FileService.get_sample_files()
         return jsonify({'files': sample_files})
@@ -59,14 +64,18 @@ def list_sample_files():
 
 @bp.route('/load-sample/<filename>')
 def load_sample_file(filename):
-    """Charge un fichier KML d'exemple."""
+    """Charge un fichier d'exemple (KML ou GPX)."""
     try:
         # Récupérer le mode d'affichage depuis les paramètres de requête
         display_mode = request.args.get('display_mode', 'double')
         
         # Charger le fichier
         content = FileService.load_sample_file(filename)
-        result = KMLParser.parse_kml_coordinates(content, display_mode)
+        ext = filename.rsplit('.', 1)[1].lower()
+        if ext == 'gpx':
+            result = GPXParser.parse_gpx_coordinates(content)
+        else:
+            result = KMLParser.parse_kml_coordinates(content, display_mode)
         
         return jsonify(result)
         

--- a/web-app/app/config.py
+++ b/web-app/app/config.py
@@ -15,7 +15,7 @@ class Config:
     
     # Configuration des uploads
     UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER') or 'uploads'
-    ALLOWED_EXTENSIONS = {'kml', 'kmz'}
+    ALLOWED_EXTENSIONS = {'kml', 'kmz', 'gpx'}
     
     # Configuration des fichiers d'exemple
     SAMPLE_FILES_DIR = os.environ.get('SAMPLE_FILES_DIR') or '/app/sample_files'

--- a/web-app/app/services/file_service.py
+++ b/web-app/app/services/file_service.py
@@ -10,57 +10,56 @@ from flask import current_app
 
 
 class FileService:
-    """Service de gestion des fichiers KML."""
+    """Service de gestion des fichiers KML/GPX."""
     
     @staticmethod
     @track_time
     def allowed_file(filename: str) -> bool:
         """Vérifie si le fichier a une extension autorisée."""
-        return ('.' in filename and 
-                filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS'])
+        return (
+            '.' in filename
+            and filename.rsplit('.', 1)[1].lower()
+            in current_app.config['ALLOWED_EXTENSIONS']
+        )
     
     @staticmethod
     @track_time
     def get_sample_files() -> List[Dict[str, str]]:
-        """Liste les fichiers KML d'exemple disponibles."""
+        """Liste les fichiers d'exemple disponibles."""
         sample_files = []
         
         # Chercher dans le dossier sample_files monté par Docker
         sample_dir = Path(current_app.config['SAMPLE_FILES_DIR'])
         if sample_dir.exists():
-            for file_path in sample_dir.glob('*.kml'):
-                sample_files.append({
-                    'name': file_path.name,
-                    'path': str(file_path.name)
-                })
+            for file_path in sample_dir.glob('*.*'):
+                if file_path.suffix.lower() in {'.kml', '.gpx'}:
+                    sample_files.append({'name': file_path.name, 'path': str(file_path.name)})
         else:
             # Fallback pour le développement local
             project_root = Path(current_app.config['SAMPLE_FILES_FALLBACK'])
             if project_root.exists():
-                for file_path in project_root.glob('*.kml'):
-                    sample_files.append({
-                        'name': file_path.name,
-                        'path': str(file_path.name)
-                    })
+                for file_path in project_root.glob('*.*'):
+                    if file_path.suffix.lower() in {'.kml', '.gpx'}:
+                        sample_files.append({'name': file_path.name, 'path': str(file_path.name)})
         
         return sample_files
     
     @staticmethod
     @track_time
     def load_sample_file(filename: str) -> str:
-        """Charge le contenu d'un fichier KML d'exemple."""
+        """Charge le contenu d'un fichier d'exemple."""
         secure_name = secure_filename(filename)
         
         # Chercher d'abord dans le dossier sample_files monté par Docker
         sample_path = Path(current_app.config['SAMPLE_FILES_DIR']) / secure_name
-        if sample_path.exists() and sample_path.suffix.lower() == '.kml':
+        if sample_path.exists() and sample_path.suffix.lower() in {'.kml', '.gpx'}:
             file_path = sample_path
         else:
             # Fallback pour le développement local
             project_root = Path(current_app.config['SAMPLE_FILES_FALLBACK'])
             file_path = project_root / secure_name
         
-        if not file_path.exists() or not file_path.suffix.lower() == '.kml':
+        if not file_path.exists() or file_path.suffix.lower() not in {'.kml', '.gpx'}:
             raise FileNotFoundError('Fichier non trouvé ou type invalide')
         
         with open(file_path, 'r', encoding='utf-8') as f:
@@ -79,4 +78,4 @@ class FileService:
             content = file.read().decode('utf-8')
             return content
         except UnicodeDecodeError as exc:
-            raise ValueError('Erreur d\'encodage du fichier. Assurez-vous qu\'il s\'agit d\'un fichier KML valide.') from exc
+            raise ValueError("Erreur d'encodage du fichier. Assurez-vous qu'il s'agit d'un fichier valide.") from exc

--- a/web-app/app/services/gpx_parser.py
+++ b/web-app/app/services/gpx_parser.py
@@ -1,0 +1,159 @@
+"""GPX parsing service."""
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Dict, Any, List
+from app.services.timing_tools import track_time
+from app.services.trajectory_analyzer import TrajectoryAnalyzer
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    handlers=[logging.StreamHandler()])
+logger = logging.getLogger(__name__)
+
+class GPXParser:
+    """Simple GPX parser producing features compatible with the KML parser."""
+
+    NAMESPACES = {'gpx': 'http://www.topografix.com/GPX/1/1'}
+
+    @staticmethod
+    def _build_parsed_info(lat: float, lon: float, ele: float, speed_kmh: float = None) -> Dict[str, Any]:
+        parsed = {
+            'speed_kmh': round(speed_kmh, 1) if speed_kmh is not None else None,
+            'speed_kts': round(speed_kmh / 1.852, 1) if speed_kmh is not None else None,
+            'altitude_ft': round(ele * 3.28084) if ele is not None else None,
+            'altitude_m': ele,
+            'latitude': lat,
+            'longitude': lon,
+            'heading': None,
+            'raw_description': ''
+        }
+        return parsed
+
+    @staticmethod
+    @track_time
+    def parse_gpx_coordinates(gpx_content: str) -> Dict[str, Any]:
+        """Parse GPX content and return features and points."""
+        try:
+            ns = GPXParser.NAMESPACES
+            root = ET.fromstring(gpx_content)
+
+            metadata: Dict[str, Any] = {}
+            meta_elem = root.find('gpx:metadata', ns)
+            if meta_elem is not None:
+                name_elem = meta_elem.find('gpx:name', ns)
+                if name_elem is not None:
+                    metadata['title'] = name_elem.text
+                desc_elem = meta_elem.find('gpx:desc', ns)
+                if desc_elem is not None:
+                    metadata['description'] = desc_elem.text
+                time_elem = meta_elem.find('gpx:time', ns)
+                if time_elem is not None:
+                    metadata['time'] = time_elem.text
+
+            features: List[Dict[str, Any]] = []
+            points: List[Dict[str, Any]] = []
+
+            # Waypoints
+            for wpt in root.findall('gpx:wpt', ns):
+                lat = float(wpt.get('lat'))
+                lon = float(wpt.get('lon'))
+                ele_elem = wpt.find('gpx:ele', ns)
+                ele = float(ele_elem.text) if ele_elem is not None else 0.0
+                name_elem = wpt.find('gpx:name', ns)
+                desc_elem = wpt.find('gpx:desc', ns)
+
+                parsed_info = GPXParser._build_parsed_info(lat, lon, ele)
+                marker = {
+                    'type': 'marker',
+                    'name': name_elem.text if name_elem is not None else 'Waypoint',
+                    'description': desc_elem.text if desc_elem is not None else '',
+                    'coordinates': [lat, lon],
+                    'altitude': ele,
+                    'style': None,
+                    'visibility': "1",
+                    'time_info': {},
+                    'parsed_info': parsed_info,
+                    'properties': {}
+                }
+                features.append(marker)
+                points.append(marker)
+
+            # Tracks
+            for trk in root.findall('gpx:trk', ns):
+                trk_name_elem = trk.find('gpx:name', ns)
+                trk_desc_elem = trk.find('gpx:desc', ns)
+                trk_name = trk_name_elem.text if trk_name_elem is not None else 'Track'
+                trk_desc = trk_desc_elem.text if trk_desc_elem is not None else ''
+
+                coordinates: List[List[float]] = []
+                timestamps: List[str] = []
+                prev = None
+
+                for seg in trk.findall('gpx:trkseg', ns):
+                    for idx, trkpt in enumerate(seg.findall('gpx:trkpt', ns)):
+                        lat = float(trkpt.get('lat'))
+                        lon = float(trkpt.get('lon'))
+                        ele_elem = trkpt.find('gpx:ele', ns)
+                        ele = float(ele_elem.text) if ele_elem is not None else 0.0
+                        time_elem = trkpt.find('gpx:time', ns)
+                        timestamp = time_elem.text if time_elem is not None else None
+
+                        coordinates.append([lat, lon, ele])
+                        timestamps.append(timestamp)
+
+                        speed_kmh = None
+                        if prev and prev['time'] and timestamp:
+                            try:
+                                t1 = datetime.fromisoformat(prev['time'].replace('Z', '+00:00'))
+                                t2 = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+                                dt = (t2 - t1).total_seconds()
+                                if dt > 0:
+                                    dist = TrajectoryAnalyzer.calculate_distance_between_points(
+                                        [prev['lat'], prev['lon'], prev['ele']],
+                                        [lat, lon, ele]
+                                    )
+                                    speed_kmh = dist / dt * 3.6
+                            except Exception:
+                                speed_kmh = None
+
+                        parsed_info = GPXParser._build_parsed_info(lat, lon, ele, speed_kmh)
+                        marker = {
+                            'type': 'marker',
+                            'name': f'trkpt_{len(points)}',
+                            'description': '',
+                            'coordinates': [lat, lon],
+                            'altitude': ele,
+                            'style': None,
+                            'visibility': "0",
+                            'time_info': {'timestamp': timestamp},
+                            'parsed_info': parsed_info,
+                            'properties': {}
+                        }
+                        features.append(marker)
+                        points.append(marker)
+                        prev = {'lat': lat, 'lon': lon, 'ele': ele, 'time': timestamp}
+
+                polyline = {
+                    'type': 'polyline',
+                    'name': trk_name,
+                    'description': trk_desc,
+                    'coordinates': coordinates,
+                    'style': None,
+                    'time_info': {'timestamps': timestamps},
+                    'extensions': {},
+                    'properties': {}
+                }
+                features.append(polyline)
+
+            return {
+                'success': True,
+                'features': features,
+                'points': points,
+                'metadata': metadata,
+                'total_points': len(points)
+            }
+        except ET.ParseError as exc:
+            return {'success': False, 'error': f'Erreur de parsing XML: {str(exc)}'}
+        except Exception as exc:  # pragma: no cover - general catch
+            return {'success': False, 'error': f'Erreur lors du traitement: {str(exc)}'}

--- a/web-app/tests/test_gpx_parser.py
+++ b/web-app/tests/test_gpx_parser.py
@@ -1,0 +1,27 @@
+from app.services.gpx_parser import GPXParser
+
+
+def test_parse_gpx_basic():
+    gpx = """<?xml version='1.0' encoding='UTF-8'?>
+<gpx xmlns='http://www.topografix.com/GPX/1/1' version='1.1' creator='test'>
+  <trk>
+    <name>Test</name>
+    <trkseg>
+      <trkpt lat='0.0' lon='0.0'>
+        <ele>0</ele>
+        <time>2020-01-01T00:00:00Z</time>
+      </trkpt>
+      <trkpt lat='0.0' lon='0.1'>
+        <ele>0</ele>
+        <time>2020-01-01T00:10:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>
+"""
+    result = GPXParser.parse_gpx_coordinates(gpx)
+    assert result['success'] is True
+    assert any(f['type'] == 'polyline' for f in result['features'])
+    assert result['total_points'] == 2
+    speeds = [p['parsed_info']['speed_kmh'] for p in result['points'] if p['parsed_info']['speed_kmh']]
+    assert speeds and speeds[0] is not None


### PR DESCRIPTION
## Summary
- parse GPX files in a new `GPXParser` service
- allow uploading GPX files via config and file service
- detect file type in API upload and sample routes
- add unit test for GPX parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9a89e514832a9ce1513b200159e6