### PR TITLE
Fix speed outliers

### DIFF
--- a/web-app/tests/test_trajectory.py
+++ b/web-app/tests/test_trajectory.py
@@ -20,3 +20,18 @@ def test_calculate_elevation_profile_basic():
     assert result["min_elevation"] == 0.0
     assert result["max_elevation"] == 30.0
 
+
+def test_speed_statistics_with_outlier():
+    points = []
+    speeds = [10, 12, 11, 120, 9]
+    for i, spd in enumerate(speeds):
+        points.append({
+            'parsed_info': {'speed_kmh': spd, 'speed_kts': spd / 1.852},
+            'coordinates': [0.0, 0.0],
+        })
+
+    stats = TrajectoryAnalyzer.calculate_speed_statistics(points)
+
+    assert stats['max_speed_kmh'] < 50
+    assert stats['avg_speed_kmh'] < 20
+


### PR DESCRIPTION
## Summary
- detect and remove unrealistic speed values when computing statistics
- ignore speed outliers when analysing speed zones
- test speed statistics with an outlier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9e63a9cc832ab5163f651caf393e