### PR TITLE
Implement multi-file import with dynamic stats

### DIFF
--- a/web-app/templates/index.html
+++ b/web-app/templates/index.html
@@ -96,7 +96,10 @@
                         <i class="fas fa-chart-line me-2"></i>
                         Analyse de trajet
                     </h6>
-                    
+
+                    <!-- Onglets fichiers -->
+                    <ul class="nav nav-pills mb-3" id="fileTabs"></ul>
+
                     <!-- Onglets d'analyse -->
                     <ul class="nav nav-tabs mb-3" id="analysisTab" role="tablist">
                         <li class="nav-item" role="presentation">

--- a/web-app/templates/sidebar.html
+++ b/web-app/templates/sidebar.html
@@ -12,15 +12,21 @@
                 <i class="fas fa-cloud-upload-alt fa-2x text-muted mb-2"></i>
                 <h6>Glissez-déposez votre fichier KML/GPX ici</h6>
                 <p class="text-muted">ou cliquez pour sélectionner</p>
-                <input type="file" id="fileInput" accept=".kml,.gpx,.kmz" style="display: none;">
+                <input type="file" id="fileInput" accept=".kml,.gpx,.kmz" multiple style="display: none;">
             </div>
-            
+
             <!-- Fichiers d'exemple -->
             <div class="mt-3">
                 <h6>Fichiers d'exemple :</h6>
                 <div id="sampleFiles" class="d-flex flex-wrap gap-2">
                     <!-- Les fichiers d'exemple seront chargés ici -->
                 </div>
+            </div>
+
+            <!-- Fichiers importés -->
+            <div class="mt-3">
+                <h6>Fichiers importés :</h6>
+                <div id="uploadedFiles" class="d-flex flex-column gap-1"></div>
             </div>
         </div>
         

--- a/web-app/tests/test_app.py
+++ b/web-app/tests/test_app.py
@@ -49,6 +49,28 @@ def test_api_upload_no_file(client):
     assert 'Aucun fichier sélectionné' in json_data['error']
 
 
+def test_api_multi_upload(client):
+    """Test de l'upload multiple."""
+    from io import BytesIO
+
+    kml = """<?xml version='1.0' encoding='UTF-8'?><kml xmlns='http://www.opengis.net/kml/2.2'><Document></Document></kml>"""
+    gpx = """<?xml version='1.0' encoding='UTF-8'?><gpx xmlns='http://www.topografix.com/GPX/1/1'><trk><trkseg><trkpt lat='0' lon='0'><ele>0</ele><time>2020-01-01T00:00:00Z</time></trkpt></trkseg></trk></gpx>"""
+
+    data = {
+        'files': [
+            (BytesIO(kml.encode('utf-8')), 'a.kml'),
+            (BytesIO(gpx.encode('utf-8')), 'b.gpx'),
+        ]
+    }
+
+    response = client.post('/api/multi-upload', data=data, content_type='multipart/form-data')
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert 'files' in json_data
+    assert len(json_data['files']) == 2
+    assert all(f['success'] for f in json_data['files'])
+
+
 def test_api_upload_empty_filename(client):
     """Test de l'upload avec nom de fichier vide."""
     data = {'file': (None, '')}


### PR DESCRIPTION
## Summary
- add backend endpoint `/api/multi-upload` to handle several files at once
- allow multiple file selection in sidebar and show uploaded files list
- add file tabs and JS logic for managing multiple files on the map
- modify sample loading to use multi‑file system
- test new endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2856de48832a974a5f7703bad9dd